### PR TITLE
Change Linux implementation to parport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.10)
+
+# Set the project name
+project(xcomms LANGUAGES C CXX ASM)
+
+# Find the FLTK package
+find_package(FLTK REQUIRED)
+
+# Include FLTK directories
+include_directories(${FLTK_INCLUDE_DIRS})
+
+# Add include directories
+include_directories(include resource)
+
+# Find all source files
+file(GLOB_RECURSE SOURCES "source/*.cpp" "source/*.cxx")
+file(GLOB_RECURSE RESOURCE_SOURCES "resource/*.rc")
+file(GLOB_RECURSE DATA_SOURCES "data/*.cxx")
+
+list(APPEND SOURCES ${RESOURCE_SOURCES} ${DATA_SOURCES})
+
+# # Add assembly source files (in order to use this CMake file on Windows, this file needs to be included)
+#list(APPEND SOURCES "source/xboo_port.s")
+
+# Set compiler flags
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-multichar -Wunused -fno-rtti -fno-exceptions")
+
+
+
+# Add the executable
+add_executable(xcomms ${SOURCES})
+
+# Link FLTK libraries
+target_link_libraries(xcomms ${FLTK_LIBRARIES})

--- a/include/xcomms_cmd.h
+++ b/include/xcomms_cmd.h
@@ -1,0 +1,53 @@
+/*
+
+	Header file for libgba Xboo Communicator commands
+
+	Copyright 2003-2004 by Dave Murphy.
+
+	This library is free software; you can redistribute it and/or
+	modify it under the terms of the GNU Library General Public
+	License as published by the Free Software Foundation; either
+	version 2 of the License, or (at your option) any later version.
+
+	This library is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+	Library General Public License for more details.
+
+	You should have received a copy of the GNU Library General Public
+	License along with this library; if not, write to the Free Software
+	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+	USA.
+
+	Please report all bugs and problems through the bug tracker at
+	"http://sourceforge.net/tracker/?group_id=114505&atid=668551".
+
+*/
+
+//---------------------------------------------------------------------------------
+#ifndef _xcomms_cmd_h_
+#define _xcomms_cmd_h_
+//---------------------------------------------------------------------------------
+
+#define PRINT_CMD	('PRT'<<8)
+#define DPUTC_CMD	('DPT'<<8)
+
+#define FOPEN_CMD	('OPN'<<8)
+#define FCLOSE_CMD	('CLS'<<8)
+
+#define FREAD_CMD	('FRD'<<8)
+#define FWRITE_CMD	('FWR'<<8)
+
+#define FSEEK_CMD	('FSK'<<8)
+#define REWIND_CMD	('RWD'<<8)
+#define FTELL_CMD	('FTL'<<8)
+
+#define FGETC_CMD	('FGT'<<8)
+#define FPUTC_CMD	('FPT'<<8)
+
+#define GETCH_CMD	('GTC'<<8)
+#define KBHIT_CMD	('KBH'<<8)
+
+//---------------------------------------------------------------------------------
+#endif //_xcomms_cmd_h_
+//---------------------------------------------------------------------------------

--- a/source/config.cxx
+++ b/source/config.cxx
@@ -29,7 +29,11 @@ void ReadConfigFile(const char *file)
 		XcommsCfg.delay		= 1;
 		XcommsCfg.verify	= 1;
 		XcommsCfg.headerfix	= 1;
+#ifdef __WIN32__
 		XcommsCfg.Port		= 0x378;
+#else
+		XcommsCfg.Port		= 0x0;
+#endif
 		XcommsCfg.x			= 0;
 		XcommsCfg.y			= 0;
 		XcommsCfg.width		= WIN_MIN_WIDTH;

--- a/source/console.cxx
+++ b/source/console.cxx
@@ -228,15 +228,12 @@ void GBAConsole()
 					break;
 				//---------------------------------------------------------
 				case FCLOSE_CMD:
-					if (code < MAX_FILES)
+					if (code < MAX_FILES && Files[code].handle)
 					{
-						if (Files[code].handle)
-						{
-							fclose(Files[code].handle);
-							Log("Closed handle %d - %s\n",code,Files[code].name);
-							Files[code].handle = NULL;
-							OpenFiles--;
-						}
+						fclose(Files[code].handle);
+						Log("Closed handle %d - %s\n",code,Files[code].name);
+						Files[code].handle = NULL;
+						OpenFiles--;
 					}
 					break;
 				//---------------------------------------------------------
@@ -245,14 +242,14 @@ void GBAConsole()
 					while(ReadSOState());
 					data = XbooExchange32(0);
 
-					if (Files[code].handle)
+					if (code < MAX_FILES && Files[code].handle)
 					{
 						fputc(data,Files[code].handle);
 					}
 					break;
 				//---------------------------------------------------------
 				case FGETC_CMD:
-					if (Files[code].handle)
+					if (code < MAX_FILES && Files[code].handle)
 					{
 						data = fgetc(Files[code].handle);
 					}
@@ -270,7 +267,7 @@ void GBAConsole()
 					while (ReadSOState());
 					seek_origin = XbooExchange32(data);
 
-					if (Files[code].handle)
+					if (code < MAX_FILES && Files[code].handle)
 					{
 						fseek(Files[code].handle,seek_offset,seek_origin);
 						Log("Seek on %s: Offset %d Origin %d\n",Files[code].name, seek_offset, seek_origin);
@@ -279,7 +276,7 @@ void GBAConsole()
 				//---------------------------------------------------------
 				case FTELL_CMD:
 					data = 0xffffffff;
-					if (Files[code].handle)
+					if (code < MAX_FILES && Files[code].handle)
 					{
 						data = ftell(Files[code].handle);
 						Log("Ftell on %s\n",Files[code].name);
@@ -303,7 +300,7 @@ void GBAConsole()
 					read_buffer = (unsigned char *)malloc( ((read_length)+3)&-4);
 					read_ptr = read_buffer;
 
-					if (Files[code].handle)
+					if (code < MAX_FILES && Files[code].handle)
 					{
 						fread(read_buffer,read_size,read_count,Files[code].handle);
 						Log("Read %d bytes from %s\n",read_length,Files[code].name);
@@ -351,7 +348,7 @@ void GBAConsole()
 
 					}
 
-					if (Files[code].handle)
+					if (code < MAX_FILES && Files[code].handle)
 					{
 						fwrite(read_buffer,read_size,read_count,Files[code].handle);
 						Log("Wrote %d bytes to %s\n",read_size*read_count,Files[code].name);

--- a/source/mbv2.cxx
+++ b/source/mbv2.cxx
@@ -47,7 +47,7 @@ int inp ( short address) {
 void TimerDelay2 (int delay) {
 //-----------------------------------------------------------------------------
 
-	unsigned long delayms = delay * 9;
+	unsigned int delayms = delay * 9;
 	
 #ifdef __linux__
 	

--- a/source/options.cxx
+++ b/source/options.cxx
@@ -21,7 +21,11 @@ Fl_Counter *TxDelay;
 void OptionsOK()
 //-----------------------------------------------------------------------------
 {
+#ifdef __WIN32__
 	SetPortAddress(Port->value()?0x378:0x278);
+#else
+	SetPortAddress(Port->value());
+#endif
 	SetVerify(Verify->value());
 //	SetBurst(DoubleSpeed->value());
 	SetDelay((int)TxDelay->value());
@@ -51,9 +55,17 @@ void Options()
 		o->labeltype(FL_NO_LABEL);
 		o->labelsize(12);
 		o->textsize(12);
+#ifdef __WIN32__
 		o->add("0x278|0x378");
+#else
+		o->add("0|1");
+#endif
 		int index = 0;
+#ifdef __WIN32__
 		if (GetPortAddress() == 0x378) index = 1;
+#else
+		index = GetPortAddress();
+#endif
 		o->value(index);
 	}
 	{ Fl_Choice* o = Hardware = new Fl_Choice(125, 40, 90, 20);

--- a/source/parport.cxx
+++ b/source/parport.cxx
@@ -1,0 +1,284 @@
+#ifndef __WIN32__
+#include "xboo.h"
+#include "parport.h"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/io.h>
+
+#include <linux/ppdev.h>
+#include <sys/ioctl.h>
+
+#include <FL/fl_ask.H>
+
+#include <linux/gpio.h>
+
+#include <linux/parport.h>
+
+#include <memory>
+#include <string>
+
+// GND: Pin 6
+
+// In bit order:
+// STROBE: SC: Pin 5
+// AUTOLF: SI: Pin 3
+// SELECT: SD: Pin 4
+// ACK: SO: Pin 2
+
+// Bits:
+// 0: SC
+// 1: SI
+// 2: SD
+// 6: SO
+
+class Parport
+{
+public:
+  // PARPORT_CONTROL_INIT
+  unsigned char parport_byte = 4;
+
+  Parport(unsigned int port) : port(port)
+  {
+    std::string portname = "/dev/parport" + std::to_string(port);
+    fd = open(portname.c_str(), O_RDWR);
+    if (fd == -1)
+    {
+      fl_alert("Failed to open %s\nPlease select another port", portname.c_str());
+      return;
+    }
+
+    if (ioctl(fd, PPCLAIM) == -1)
+    {
+      fl_alert("Failed to claim %s\nMake sure no other program currently uses this parallel port", portname.c_str());
+      close(fd);
+      return;
+    }
+  }
+
+  ~Parport()
+  {
+    ioctl(fd, PPRELEASE);
+    close(fd);
+  }
+
+  void InitPort()
+  {
+    ioctl(fd, PPWCONTROL, &parport_byte);
+    ioctl(fd, PPWDATA, 0xff);
+  }
+
+  void PortDelay(int delay)
+  {
+    unsigned char al = 0;
+    for (int i = 0; i < delay * 6; i++)
+    {
+      ioctl(fd, PPRDATA, &al);
+    }
+  }
+
+  void XbooSend32(unsigned int Data)
+  {
+    unsigned int data = Data;
+    for (int i = 0; i < 32; i++)
+    {
+      bool bLeadingBit = data & 0x80000000;
+      data = data << 1;
+
+      unsigned char byte_to_send = bLeadingBit ? PARPORT_CONTROL_STROBE | PARPORT_CONTROL_INIT : PARPORT_CONTROL_STROBE | PARPORT_CONTROL_AUTOFD | PARPORT_CONTROL_INIT;
+      ioctl(fd, PPWCONTROL, &byte_to_send);
+      // Unset strobe
+      byte_to_send &= ~PARPORT_CONTROL_STROBE;
+      ioctl(fd, PPWCONTROL, &byte_to_send);
+      // Unset AUTO_LF
+      byte_to_send &= ~PARPORT_CONTROL_AUTOFD;
+      ioctl(fd, PPWCONTROL, &byte_to_send);
+    }
+  }
+
+  uint32_t XbooExchange32(uint32_t Data)
+  {
+    // in/out buffer
+    unsigned int data = Data;
+
+    unsigned char al = 0;
+    unsigned char ah = parport_byte;
+
+    for (int i = 0; i < 32; i++)
+    {
+      bool bLeadingBit = data & 0x80000000;
+      data = data << 1;
+
+      al = bLeadingBit ? 0x02 : 0x0;
+      ah &= bLeadingBit ? 0x0c : 0x0;
+
+      // invert bit & SC low
+      al ^= 0x3;
+      // saved SD state & Reset
+      al ^= ah;
+
+      // write to control port
+      ioctl(fd, PPWCONTROL, &al);
+
+      // preserve data written
+      ah = al;
+
+      // read from status port
+      ioctl(fd, PPRSTATUS, &al);
+
+      // bit 6 (ACK) to carry (GBA SO)
+      bool inbit = al & 0xc0;
+
+      // ebx+=inbit
+
+      // append read bit to data
+      data += inbit;
+
+      // restore data
+      al = ah;
+
+      // SC high
+      al--;
+
+      // write to control port
+      ioctl(fd, PPWCONTROL, &al);
+
+      // clear bit 1 (GBA SI high)
+      // al &= 0xfd;
+      al &= ~PARPORT_CONTROL_AUTOFD;
+
+      // write to control port
+      ioctl(fd, PPWCONTROL, &al);
+    }
+
+    parport_byte = al;
+    return data;
+  }
+
+  void ResetGBA()
+  {
+    unsigned char ah = parport_byte;
+    ah &= 0xfb;
+    unsigned char al = ah;
+    ioctl(fd, PPWDATA, &ah);
+
+    for (int i = 0; i < 12 * 4; i++)
+    {
+      ioctl(fd, PPRDATA, &al);
+    }
+
+    // I suppose, this was used for debugging (?)
+    // I see no reason to set this bit otherwise
+    ah |= 4;
+    al = ah;
+    ioctl(fd, PPWDATA, &al);
+  }
+
+  unsigned short CalcCRC(unsigned int data)
+  {
+    unsigned int eax = (data & 0xffff0000) | ((data & 0x0000ffff) ^ CRC1);
+
+    // For every bit, apply the CRC2 XOR on the lower 16 bits
+    for (int i = 0; i < 32; i++)
+    {
+      bool bHadBit = eax & 1;
+      eax >>= 1;
+      if (bHadBit)
+      {
+        eax = (eax & 0xffff0000) | ((eax & 0x0000ffff) ^ CRC2);
+      }
+    }
+
+    CRC1 = eax;
+    return CRC1;
+  }
+
+  void InitCRC()
+  {
+    CRC1 = 0xc387;
+    CRC2 = 0xc37b;
+  }
+
+  int ReadSOState()
+  {
+    unsigned char al;
+    for (int i = 0; i < 8; i++)
+    {
+      ioctl(fd, PPRSTATUS, &al);
+    }
+    return al & PARPORT_STATUS_ACK;
+  }
+
+  short GetPortAddress()
+  {
+    return port;
+  }
+
+private:
+  int fd;
+  short port;
+
+  unsigned short CRC1;
+  unsigned short CRC2;
+};
+
+static std::unique_ptr<Parport> parport;
+
+void ResetGBA()
+{
+  parport->ResetGBA();
+}
+void InitPort()
+{
+  parport->InitPort();
+}
+
+void PortDelay(int delay)
+{
+  parport->PortDelay(delay);
+}
+void InitCRC()
+{
+  parport->InitCRC();
+}
+int ReadSOState()
+{
+  return parport->ReadSOState();
+}
+
+void XbooSend32(unsigned int Data)
+{
+  parport->XbooSend32(Data);
+}
+
+unsigned int XbooExchange32(unsigned int Data)
+{
+  return parport->XbooExchange32(Data);
+}
+unsigned short CalcCRC(unsigned int data)
+{
+  return parport->CalcCRC(data);
+}
+
+short GetPortAddress()
+{
+  return parport->GetPortAddress();
+}
+void SetPortAddress(short Address)
+{
+  // Reopen the port for a new address
+  if (!parport)
+  {
+    parport = std::make_unique<Parport>(Address);
+    return;
+  }
+
+  if (parport->GetPortAddress() != Address)
+  {
+    parport.reset();
+    parport = std::make_unique<Parport>(Address);
+  }
+}
+#endif

--- a/source/xcomms.cxx
+++ b/source/xcomms.cxx
@@ -66,11 +66,6 @@ void quit(Fl_Button*, void*)
 
 	WriteConfigFile(ConfigFile.c_str());
 
-#ifndef __WIN32__
-	ioperm(0x278, 4, 0);
-	ioperm(0x378, 4, 0);
-#endif
-
 	exit(0);
 }
 
@@ -78,10 +73,10 @@ char GBArom[256*1024];
 
 typedef struct
 {
-	unsigned long	start_code;			// B instruction
+	uint32_t start_code;			// B instruction
 	unsigned char	logo[0xA0-0x04];	// logo data
 	char			title[0xC];			// game title name
-	unsigned long	game_code;			//
+	uint32_t game_code;			//
 	unsigned short	maker_code;			//
 	unsigned char	fixed;				// 0x96
 	unsigned char	unit_code;			// 0x00
@@ -291,17 +286,12 @@ int main(int argc, char **argv)
 	LogWindow->buffer()->add_modify_callback(LogChanged_cb, xcomms);
 
 
-	Log("Xboo Communicator "VERSION" - %s\n", __DATE__);
+	Log("Xboo Communicator " VERSION " - %s\n", __DATE__);
 	#ifdef __WIN32__
 		separator = "\\";
 
 	#else
 		separator = "/";
-		if ( ioperm(0x278, 4, 1) || ioperm(0x378, 4, 1) ) {
-			fl_alert("Xboo Conmmunicator requires root privileges\nfor raw parallel port access");
-			exit(0);
-		}
-
 	#endif
 
 #ifdef __MINGW32__


### PR DESCRIPTION
This changeset allows to run Xboo Communicator on current Linux computers, without root permissions.
It was tested on a x86_64 computer with Ubuntu 22.04.5 with the XbooPrint and XbooLoad examples.

It removes the old ioperm and in/out based code for Linux and instead uses the parport UAPI.

Furthermore it changes the meaning of "port address", as it now refers to the currently available parallel port device as seen by the Linux kernel. (Currently limited to two devices, could be changed in the futures).

It might now be possible to use USB to parallel port adapters (untested).
In that case, it's most likely required to select "port 1" as "port 0" is usually occupied by the chipset on the mainboard.

Please ensure, that you have sufficient permissions to access the parport device.
Usually this means adding the user to the "lp" group, logging out and logging back in.
```sh
sudo usermod -a -G lp [username]
```